### PR TITLE
Update HelloImGui / Use HelloImGui::ImTextureIdFromAsset

### DIFF
--- a/src/Explorer.cpp
+++ b/src/Explorer.cpp
@@ -14,8 +14,6 @@ void Explorer::Run()
 	m_params.callbacks.ShowGui = [this]() { Render(); };
 	m_params.callbacks.SetupImGuiStyle = [this]() { SetStyle(); };
 	m_params.callbacks.LoadAdditionalFonts = [this]() { LoadFonts(); };
-	m_params.callbacks.PostInit = [this]() { BeginApp(); };
-	m_params.callbacks.BeforeExit = [this]() { EndApp(); };
 
 	m_params.appWindowParams.windowSize = ImVec2(1200, 900);
 	m_params.appWindowParams.windowTitle = "Catsight";
@@ -128,16 +126,6 @@ void Explorer::LoadFonts()
 	HelloImGui::MergeFontAwesomeToLastFont(15, configIcons);
 }
 
-void Explorer::BeginApp()
-{
-	m_imgBackground = HelloImGui::ImageGl::FactorImage("images/background.jpg");
-}
-
-void Explorer::EndApp()
-{
-	m_imgBackground = nullptr;
-}
-
 Inspector* Explorer::GetInspector(const ProcessInfo& info)
 {
 	return GetInspector(info.pid);
@@ -245,7 +233,7 @@ void Explorer::Render()
 	m_lastFrame = tmNow;
 
 	auto draw = ImGui::GetWindowDrawList();
-	draw->AddImage(m_imgBackground->imTextureId, ImVec2(0, 0), ImGui::GetWindowSize());
+	draw->AddImage(HelloImGui::ImTextureIdFromAsset("images/background.jpg"), ImVec2(0, 0), ImGui::GetWindowSize());
 
 	for (auto inspector : m_inspectors) {
 		inspector->Update(dt);

--- a/src/Explorer.h
+++ b/src/Explorer.h
@@ -13,7 +13,6 @@ public:
 	static Explorer* Instance;
 
 private:
-	HelloImGui::ImageGlPtr m_imgBackground;
 	HelloImGui::RunnerParams m_params;
 
 	Chrono::Time m_lastFrame;
@@ -31,9 +30,6 @@ public:
 
 	void SetStyle();
 	void LoadFonts();
-
-	void BeginApp();
-	void EndApp();
 
 	Inspector* GetInspector(const ProcessInfo& info);
 	Inspector* GetInspector(int pid);


### PR DESCRIPTION
Hi,

Just a quick (and optional) PR. 

I just updated HelloImGui by adding [image_from_asset](https://github.com/pthom/hello_imgui/blob/master/src/hello_imgui/image_from_asset.h) : this provides utilities to load and display images from assets and let HelloImGui handle their lifetime.

See [image_from_asset.h](https://github.com/pthom/hello_imgui/blob/master/src/hello_imgui/image_from_asset.h) and [image_from_asset.cpp](https://github.com/pthom/hello_imgui/blob/master/src/hello_imgui/internal/image_from_asset.cpp) in HelloImGui.

This enables to simplify a bit the code of the Explorer class.

